### PR TITLE
Add documentation strings across modules

### DIFF
--- a/src/campaign_fetcher.py
+++ b/src/campaign_fetcher.py
@@ -1,6 +1,9 @@
+"""Fetches campaign data from the API and stores it in MySQL."""
+
 import logging
 
 class CampaignFetcher:
+    """Retrieve and persist campaign information via ``fetch_and_store``."""
     def __init__(self, api_client, transformer, db_manager):
         self.api_client = api_client
         self.transformer = transformer

--- a/src/config.py
+++ b/src/config.py
@@ -1,9 +1,12 @@
+"""Configuration loading and logging setup utilities."""
+
 import os
 import json
 import logging
 from logging.handlers import RotatingFileHandler
 
 class Config:
+    """Load settings from a file or environment variables."""
     def __init__(self, config_file=None):
         self.settings = {
             'DB_HOST': 'localhost',

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -1,3 +1,5 @@
+"""Shared pytest fixtures for database setup and environment configuration."""
+
 import pytest
 import os
 from test_utils import clean_test_db, assert_using_test_db

--- a/src/database_manager.py
+++ b/src/database_manager.py
@@ -1,3 +1,5 @@
+"""Database access layer with connection pooling and upsert helpers."""
+
 import os
 import mysql.connector
 from mysql.connector import pooling
@@ -19,6 +21,7 @@ def get_db_credentials():
     }
 
 class DatabaseManager:
+    """Manages the connection pool and provides upsert methods for entities."""
     def __init__(self):
         creds = get_db_credentials()
         self.pool = pooling.MySQLConnectionPool(

--- a/src/helldivers_api_client.py
+++ b/src/helldivers_api_client.py
@@ -1,8 +1,11 @@
+"""HTTP client wrapper for the Helldivers 2 API with retry support."""
+
 import requests
 import logging
 import time
 
 class Helldivers2ApiClient:
+    """Simple wrapper exposing methods for each Helldivers API endpoint."""
     BASE_URL = 'https://helldiverstrainingmanual.com/api/v1/war'
 
     def __init__(self, max_retries=3, timeout=10):

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,5 @@
+"""Command line interface for running and scheduling pipeline updates."""
+
 import argparse
 import sys
 import os

--- a/src/major_orders_fetcher.py
+++ b/src/major_orders_fetcher.py
@@ -1,6 +1,9 @@
+"""Fetches major orders and writes them to the database."""
+
 import logging
 
 class MajorOrdersFetcher:
+    """Coordinates retrieval and storage of major orders."""
     def __init__(self, api_client, transformer, db_manager):
         self.api_client = api_client
         self.transformer = transformer

--- a/src/news_fetcher.py
+++ b/src/news_fetcher.py
@@ -1,6 +1,9 @@
+"""Fetches news entries and persists them via the database manager."""
+
 import logging
 
 class NewsFetcher:
+    """Handle retrieval and storage of news via ``fetch_and_store``."""
     def __init__(self, api_client, transformer, db_manager):
         self.api_client = api_client
         self.transformer = transformer

--- a/src/planet_fetcher.py
+++ b/src/planet_fetcher.py
@@ -1,6 +1,9 @@
+"""Imports planet definitions and their environmentals."""
+
 import logging
 
 class PlanetFetcher:
+    """Transforms planet data and persists each record."""
     def __init__(self, api_client, transformer, db_manager):
         self.api_client = api_client
         self.transformer = transformer

--- a/src/planet_history_fetcher.py
+++ b/src/planet_history_fetcher.py
@@ -1,6 +1,9 @@
+"""Collects historical planet data for all planets."""
+
 import logging
 
 class PlanetHistoryFetcher:
+    """Downloads planet history and records each entry."""
     def __init__(self, api_client, transformer, db_manager):
         self.api_client = api_client
         self.transformer = transformer

--- a/src/test_campaign_fetcher.py
+++ b/src/test_campaign_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``CampaignFetcher`` class."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/test_config.py
+++ b/src/test_config.py
@@ -1,3 +1,5 @@
+"""Tests for the configuration and logging utilities."""
+
 import os
 import json
 import logging

--- a/src/test_database_manager.py
+++ b/src/test_database_manager.py
@@ -1,3 +1,5 @@
+"""Tests for the ``DatabaseManager`` utility functions."""
+
 import pytest
 from database_manager import DatabaseManager
 from test_utils import clean_test_db, assert_using_test_db

--- a/src/test_helldivers_api_client.py
+++ b/src/test_helldivers_api_client.py
@@ -1,3 +1,4 @@
+"""Tests for the ``Helldivers2ApiClient`` HTTP wrapper."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/test_major_orders_fetcher.py
+++ b/src/test_major_orders_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``MajorOrdersFetcher`` component."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/test_news_fetcher.py
+++ b/src/test_news_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``NewsFetcher`` class."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/test_planet_fetcher.py
+++ b/src/test_planet_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``PlanetFetcher`` component."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/test_planet_history_fetcher.py
+++ b/src/test_planet_history_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``PlanetHistoryFetcher`` class."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import os

--- a/src/test_transformers.py
+++ b/src/test_transformers.py
@@ -1,3 +1,5 @@
+"""Tests for the various data transformers."""
+
 import pytest
 from transformers.planet_transformer import PlanetTransformer
 from transformers.war_status_transformer import WarStatusTransformer

--- a/src/test_update_orchestrator.py
+++ b/src/test_update_orchestrator.py
@@ -1,3 +1,5 @@
+"""Integration tests for the ``UpdateOrchestrator`` class."""
+
 import pytest
 from update_orchestrator import UpdateOrchestrator
 from config import Config, setup_logging

--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers shared across tests for DB cleanup."""
+
 import os
 from database_manager import DatabaseManager
 

--- a/src/test_war_info_fetcher.py
+++ b/src/test_war_info_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``WarInfoFetcher`` module."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/test_war_status_fetcher.py
+++ b/src/test_war_status_fetcher.py
@@ -1,3 +1,4 @@
+"""Tests for the ``WarStatusFetcher`` class."""
 # Fixtures removed; now using shared fixtures from conftest.py
 
 import pytest

--- a/src/transformers/campaign_transformer.py
+++ b/src/transformers/campaign_transformer.py
@@ -1,3 +1,5 @@
+"""Transforms campaign API responses into DB-ready dictionaries."""
+
 from datetime import datetime
 
 class CampaignTransformer:

--- a/src/transformers/major_order_transformer.py
+++ b/src/transformers/major_order_transformer.py
@@ -1,3 +1,5 @@
+"""Transforms major order API data for ingestion."""
+
 from datetime import datetime, timedelta
 import json
 

--- a/src/transformers/news_transformer.py
+++ b/src/transformers/news_transformer.py
@@ -1,3 +1,5 @@
+"""Transforms news API entries into database format."""
+
 from datetime import datetime
 import logging
 import json

--- a/src/transformers/planet_history_transformer.py
+++ b/src/transformers/planet_history_transformer.py
@@ -1,3 +1,5 @@
+"""Transforms planet history API responses for storage."""
+
 from datetime import datetime
 
 class PlanetHistoryTransformer:

--- a/src/transformers/planet_transformer.py
+++ b/src/transformers/planet_transformer.py
@@ -1,3 +1,5 @@
+"""Normalizes planet API results for database insertion."""
+
 from datetime import datetime
 
 class PlanetTransformer:

--- a/src/transformers/war_info_transformer.py
+++ b/src/transformers/war_info_transformer.py
@@ -1,3 +1,5 @@
+"""Converts war info API response to war, planet, and home world records."""
+
 import json
 from datetime import datetime
 

--- a/src/transformers/war_status_transformer.py
+++ b/src/transformers/war_status_transformer.py
@@ -1,3 +1,5 @@
+"""Transforms war status responses into database-friendly structures."""
+
 from datetime import datetime, UTC
 
 class WarStatusTransformer:

--- a/src/update_orchestrator.py
+++ b/src/update_orchestrator.py
@@ -1,3 +1,5 @@
+"""Runs each fetcher in sequence to refresh the local database."""
+
 import logging
 from datetime import datetime
 from helldivers_api_client import Helldivers2ApiClient
@@ -18,6 +20,7 @@ from transformers.war_info_transformer import WarInfoTransformer
 from war_info_fetcher import WarInfoFetcher
 
 class UpdateOrchestrator:
+    """Initialize clients and coordinate the update workflow."""
     def __init__(self, config):
         self.config = config
         self.logger = logging.getLogger(__name__)

--- a/src/war_info_fetcher.py
+++ b/src/war_info_fetcher.py
@@ -1,7 +1,10 @@
+"""Fetches static war information such as planet layout and home worlds."""
+
 import logging
 from transformers.war_info_transformer import WarInfoTransformer
 
 class WarInfoFetcher:
+    """Load and store war info, ensuring referenced factions exist."""
     def __init__(self, api_client, db_manager):
         self.api_client = api_client
         self.db_manager = db_manager

--- a/src/war_status_fetcher.py
+++ b/src/war_status_fetcher.py
@@ -1,6 +1,9 @@
+"""Updates the current war status and planet metrics."""
+
 import logging
 
 class WarStatusFetcher:
+    """Handles fetching, transforming and persisting war status."""
     def __init__(self, api_client, transformer, db_manager):
         self.api_client = api_client
         self.transformer = transformer


### PR DESCRIPTION
## Summary
- add concise module docstrings to all source and test modules
- document key classes such as `CampaignFetcher`, `NewsFetcher` and `DatabaseManager`

## Testing
- `pytest -m "not complete" -q` *(fails: `pytest` not installed)*